### PR TITLE
Example of old SDK library build code

### DIFF
--- a/trunk/tools/nuget-example/make-package.cmd
+++ b/trunk/tools/nuget-example/make-package.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+
+"%LANDIS_SDK%\tools\nuget.exe" pack package.nuspec

--- a/trunk/tools/nuget-example/make-package.sh
+++ b/trunk/tools/nuget-example/make-package.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+mono $LANDIS_SDK/tools/nuget.exe pack package.nuspec

--- a/trunk/tools/nuget-example/package.nuspec
+++ b/trunk/tools/nuget-example/package.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+	<title>LANDIS-II Biomass Harvest</title>
+    <id>Landis.Library.BiomassHarvest</id>
+    <version>1.1.0</version>
+	<authors>LANDIS-II developers (see Contributors in NOTICE.txt)</authors>
+    <description>Code for cutting biomass cohorts.  Includes functionality for partial harvesting.</description>
+    <releaseNotes>Includes XML documentation file.</releaseNotes>
+	<projectUrl>https://code.google.com/p/landis-extensions/source/browse/#svn%2Flibs%2Fbiomass-harvest%2Ftrunk</projectUrl>
+	<licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+	<tags>LANDIS-II harvest biomass</tags>
+	<dependencies>
+	  <dependency id="Landis.Library.SiteHarvest" version="[1.0.0,2.0)" />
+	</dependencies>
+  </metadata>
+  <files>
+    <file src="..\src\bin\Release\Landis.Library.BiomassHarvest-v1.dll" target="lib\net35" />
+    <file src="..\src\bin\Release\Landis.Library.BiomassHarvest-v1.xml" target="lib\net35" />
+  </files>
+</package>


### PR DESCRIPTION
We can remove the SDK installer build commands from support libraries b/c all of these libraries now reside in Support-Library-DLLs . An example is kept here for posterity.